### PR TITLE
chore: add security hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+DFINITY takes the security of our software products seriously, which includes all source code repositories under the [DFINITY](https://github.com/dfinity) GitHub organization.
+
+> [!IMPORTANT]
+> [DFINITY Foundation](https://dfinity.org) has a [Internet Computer (ICP) Bug Bounty program](https://dfinity.org/bug-bounty/) that rewards researchers for finding and reporting vulnerabilities in the Internet Computer. Please check the scope and eligibility criteria outlined in the policy to see if the vulnerability you found qualifies for a reward.
+
+## How to report a vulnerability
+
+We appreciate your help in keeping our projects secure.
+If you believe you have found a security vulnerability in any of our repositories, please report it responsibly to us as described below:
+
+1. **Do not disclose the vulnerability publicly.** Public disclosure could be exploited by attackers before it can be fixed.
+2. **Send an email to securitybugs@dfinity.org.** Please include the following information in your email:
+    * A description of the vulnerability
+    * Steps to reproduce the vulnerability
+    * Risk rating of the vulnerability
+    * Any other relevant information
+
+We will respond to your report within 72 hours and work with you to fix the vulnerability as soon as possible.
+
+### Security Updates
+
+We are committed to fixing security vulnerabilities in a timely manner. Once a security vulnerability is reported, we will:
+
+* Investigate the report and confirm the vulnerability.
+* Develop a fix for the vulnerability.
+* Release a new version of the project that includes the fix.
+* Announce the security fix in the project's release notes.
+
+## Preferred Language
+
+We prefer all communications to be in English.
+
+## Disclaimer
+
+This security policy is subject to change at any time.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,4 @@ packages:
   - 'packages/pic'
   - 'packages/pic-server'
   - 'docs'
+minimumReleaseAge: 10080 # ignore dependency updates released less than 7 days ago


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with DFINITY's vulnerability reporting policy and bug bounty program details
- Add `minimumReleaseAge: 10080` to `pnpm-workspace.yaml` to ignore dependency updates released less than 7 days ago
- Add `ignore-scripts=true` to `.npmrc` to prevent lifecycle scripts from running during install (supply-chain attack mitigation)

## Context

Part of SDK-2664 security hardening across JS/TS repos.

> **Note:** The root `postinstall` script (extracting NNS state archive) will be suppressed by `ignore-scripts=true`. Run `pnpm run postinstall` manually when setting up the environment for NNS proxy tests.

## CI failures

CI failures are **pre-existing** and unrelated to this PR. The lockfile is out of date — `packages/pic/package.json` was updated to use `@icp-sdk/core` but `pnpm-lock.yaml` still references `@dfinity/agent`, `@dfinity/candid`, `@dfinity/identity`, `@dfinity/principal`. Additionally, example workspace packages still reference `@dfinity/pic: workspace:*` but the package was renamed. A separate PR will address these issues.